### PR TITLE
Save and load items

### DIFF
--- a/Assets/Scripts/Pickables/Pickables.cs
+++ b/Assets/Scripts/Pickables/Pickables.cs
@@ -15,10 +15,20 @@ public class Pickables : MonoBehaviour
     public bool ForceGlove { private set; get; }
     [HideInInspector]public int fuel;
 
-    private void Awake()
+    public void Awake()
     {
+        // Loading from a save triggers reconstruct of items. During that, data might be null
+        if (data == null)
+        {
+            this.enabled = false;
+            return;
+        }
+
+        this.enabled = true; // Awake can be called manually. Ensure that the script is active.
+        
         if(TryGetComponent(out _spriteRenderer))
             _spriteRenderer.sprite = data.sprite;
+        
         IsNote = data.note.Length > 0;
         HasFuel = data.fuel > 0;
         RocketBoots = data.rocketBoots;

--- a/Assets/Scripts/Player/PlayerMechanics.cs
+++ b/Assets/Scripts/Player/PlayerMechanics.cs
@@ -60,6 +60,9 @@ namespace Player
 
             // Prefab guarantees existence
             playerVitalSignLight = GameObject.FindWithTag("PlayerVitalSignLight").GetComponent<Light2D>();
+
+            if(SaveAndLoad.PendingSaveLoad)
+                SaveAndLoad.LoadItems();
         }
 
         private void Update()
@@ -164,7 +167,13 @@ namespace Player
             _pickableItem = other.gameObject;
         }
 
-        private void PickItem(GameObject constructedObject = null)
+        /// <summary>
+        /// Picks an item if found on range. If <see cref="constructedObject"/> is valid, that will be picked instead
+        /// and usually considered <see cref="_pickableRange"/> will be ignored.
+        /// </summary>
+        /// <param name="constructedObject">If valid, <see cref="_pickableRange"/> will be ignored and this will be set as
+        /// <see cref="_pickableItem"/> </param>
+        public void PickItem(GameObject constructedObject = null)
         {
             if (constructedObject == null)
             {

--- a/Assets/Scripts/Player/PlayerMechanics.cs
+++ b/Assets/Scripts/Player/PlayerMechanics.cs
@@ -51,7 +51,8 @@ namespace Player
             _playerControls.Surface.PauseMenu.started += _ => _canvasManager.SetPauseMenuActive();
             _playerControls.Surface.Shoot.performed += ctx => _playerGun.Shoot(ctx.ReadValue<float>());
             _playerControls.Surface.Push.started += _ => _forceGlove.Push();
-            _playerControls.Surface.Flashlight.started += _ => SwitchEquipment();
+            //_playerControls.Surface.Flashlight.started += _ => SwitchEquipment();
+            _playerControls.Surface.Flashlight.started += _ => SaveAndLoad.Test();
             _playerControls.Surface.Interact.started += _ => PickItem();
             
             _health = gameObject.GetComponent<Health>();
@@ -163,12 +164,23 @@ namespace Player
             _pickableItem = other.gameObject;
         }
 
-        private void PickItem()
+        private void PickItem(GameObject constructedObject = null)
         {
-            if (!_pickableRange) return;
+            if (constructedObject == null)
+            {
+                if (!_pickableRange) return;
+            }
+            else
+            {
+                _pickableItem = constructedObject;
+            }
+            
             SpecialPickups(_pickableItem);
+            
             _pickableItem.gameObject.SetActive(false);
+            
             if (!_pickableItem.TryGetComponent(out Pickables component) || !component.IsNote) return;
+            
             _canvasManager.ShowText(component.GetNote(), component.GetPicture());
             var sprite = _pickableItem.GetComponent<SpriteRenderer>().sprite;
             _canvasManager.AddNewNote(sprite, component.GetPicture(), component.GetNote(), _currentLocation);

--- a/Assets/Scripts/Player/PlayerMechanics.cs
+++ b/Assets/Scripts/Player/PlayerMechanics.cs
@@ -51,8 +51,7 @@ namespace Player
             _playerControls.Surface.PauseMenu.started += _ => _canvasManager.SetPauseMenuActive();
             _playerControls.Surface.Shoot.performed += ctx => _playerGun.Shoot(ctx.ReadValue<float>());
             _playerControls.Surface.Push.started += _ => _forceGlove.Push();
-            //_playerControls.Surface.Flashlight.started += _ => SwitchEquipment();
-            _playerControls.Surface.Flashlight.started += _ => SaveAndLoad.Test();
+            _playerControls.Surface.Flashlight.started += _ => SwitchEquipment();
             _playerControls.Surface.Interact.started += _ => PickItem();
             
             _health = gameObject.GetComponent<Health>();

--- a/Assets/Scripts/Player/SaveAndLoad.cs
+++ b/Assets/Scripts/Player/SaveAndLoad.cs
@@ -26,24 +26,24 @@ namespace Player
         {
             // Debug test saving and loading
             
-            SaveStatus(FallBackScene);
+            SaveStatus();
 
             LoadLastSave();
         }
         
         /// <summary>
-        /// Serializes and saves a <see cref="LevelStatus"/> to a file. Currently picked up items will also be saved.
+        /// Serializes and saves a <see cref="LevelStatus"/> to a file.
+        /// The savfe LevelStatus will include the current name of the scene and currently picked up items.
         /// </summary>
-        /// <param name="scene">String path to the scene</param>
-        public static void SaveStatus(string scene)
+        public static void SaveStatus()
         {
             try
             {
                 var binaryFormatter = new BinaryFormatter();
                 var fileStream = File.Create(Application.persistentDataPath + SerializedLevelStatusPath);
         
-                // Create a new LevelStatus based on given parameters and CurrentPickedItems
-                var newLevelStatus = new LevelStatus(scene, CurrentlyPickedItems);
+                // Saved scene will almost always be the current one
+                var newLevelStatus = new LevelStatus(SceneManager.GetActiveScene().name, CurrentlyPickedItems);
                 
                 binaryFormatter.Serialize(fileStream, newLevelStatus);
         

--- a/Assets/Scripts/Player/SaveAndLoad.cs
+++ b/Assets/Scripts/Player/SaveAndLoad.cs
@@ -29,12 +29,6 @@ namespace Player
             SaveStatus(FallBackScene);
 
             LoadLastSave();
-            
-            foreach (var item in CurrentlyPickedItems)
-            {
-                //Debug.Log(item);
-            }
-            
         }
         
         /// <summary>
@@ -64,7 +58,7 @@ namespace Player
         /// <summary>
         /// Load the serialized <see cref="LevelStatus"/> from a file and deserializes it.
         /// </summary>
-        /// <returns> <see cref="LevelStatus"/> </returns>
+        /// <returns> <see cref="LevelStatus"/>Deserialized save file</returns>
         public static LevelStatus LoadStatus()
         {
             try
@@ -92,6 +86,8 @@ namespace Player
     
         /// <summary>
         /// Loads the scene in <see cref="LevelStatus"/> and sets <see cref="PendingSaveLoad"/> to true.
+        /// Other executing functions will handle the rest like <see cref="LoadItems"/>
+        /// If loaded LevelStatus is not valid, nothing will happen.
         /// </summary>
         public static void LoadLastSave()
         {


### PR DESCRIPTION
Items can now be saved and loaded.

It almost works as intended. When loading items, their pickup sounds will be played at the same time and Notes will fuck up the game.