### PR TITLE
MonoBehaviour to enable saving level status in cutscenes.

### DIFF
--- a/Assets/Scripts/Player/SaveAndLoad.cs
+++ b/Assets/Scripts/Player/SaveAndLoad.cs
@@ -52,6 +52,8 @@ namespace Player
                 binaryFormatter.Serialize(fileStream, newLevelStatus);
         
                 fileStream.Close();
+
+                Debug.Log($"Succesfully saved status in place {place}");
             }
             catch (Exception e)
             {

--- a/Assets/Scripts/Player/SaveLevelStatusBehaviour.cs
+++ b/Assets/Scripts/Player/SaveLevelStatusBehaviour.cs
@@ -1,0 +1,16 @@
+using System;
+using UnityEngine;
+
+namespace Player
+{
+    public class SaveLevelStatusBehaviour : MonoBehaviour
+    {
+        private void Start() => DontDestroyOnLoad(this); // Can be used between levels
+
+        /// <summary>
+        /// This is just forward the call to <see cref="SaveAndLoad.SaveStatus"/> because in the editor it has to be an instance.
+        /// </summary>
+        /// <param name="place">Used to execute additional instructions</param>
+        public void SaveStatus(string place) => SaveAndLoad.SaveStatus(place);
+    }
+}

--- a/Assets/Scripts/Player/SaveLevelStatusBehaviour.cs.meta
+++ b/Assets/Scripts/Player/SaveLevelStatusBehaviour.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1101e2816afe1724f9e68a33d182c97a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
FirstMap now includes a gameobject with SaveLevelStatusMonoBehaviour. It should be alive in following scenes, though there aren't any plans for other levels.

Start cutscene now saves level status.