### PR TITLE
Save point player locations

### DIFF
--- a/Assets/Scripts/Player/SaveAndLoad.cs
+++ b/Assets/Scripts/Player/SaveAndLoad.cs
@@ -193,6 +193,9 @@ namespace Player
                     var newRoute = GameObject.Find("NewRoute");
                     newRoute.SetActive(true);
                     
+                    // Move the player approximately to the location where it should be after the cutscene
+                    var player = GameObject.FindWithTag("Player").transform.position = new Vector3(268.5f, 72.4f, 0);
+                    
                     break;
                 }
                 default:

--- a/Assets/Scripts/Player/SaveLevelStatusBehaviour.cs
+++ b/Assets/Scripts/Player/SaveLevelStatusBehaviour.cs
@@ -5,8 +5,6 @@ namespace Player
 {
     public class SaveLevelStatusBehaviour : MonoBehaviour
     {
-        private void Start() => DontDestroyOnLoad(this); // Can be used between levels
-
         /// <summary>
         /// This is just forward the call to <see cref="SaveAndLoad.SaveStatus"/> because in the editor it has to be an instance.
         /// </summary>


### PR DESCRIPTION
- Bug fix with multiple SaveLevelStatus-gameobjects
- AfterSpaceShip savepoint now moves the player to the correct location