### PR TITLE
Morko lair collapse

### DIFF
--- a/Assets/Prefabs/Enemies/Morko.prefab
+++ b/Assets/Prefabs/Enemies/Morko.prefab
@@ -706,7 +706,7 @@ GameObject:
   - component: {fileID: 1103079086}
   m_Layer: 0
   m_Name: Morko
-  m_TagString: Untagged
+  m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scripts/Enemies/MorkoEnemy.cs
+++ b/Assets/Scripts/Enemies/MorkoEnemy.cs
@@ -24,6 +24,8 @@ public class MorkoEnemy : MonoBehaviour
     private readonly float attackCooldown = 1f;
     private bool _canAttack = true;
 
+    private bool _isMorkoStopped;
+
     private bool isMorkoAwake = false;
 
     public AudioSource[] morkoSteps;
@@ -84,6 +86,14 @@ public class MorkoEnemy : MonoBehaviour
         
         if(distanceToPlayer > data.enemyRange)
             return;
+
+        if (_isMorkoStopped) // Stop Mörkö when he arrives at the edge of the collapsed cliff
+        {
+            _canAttack = true; // If the player tries to jump towards the Mörkö, it has to be able to attack
+            return; 
+        }
+            
+            
         
         _animator.SetTrigger(Walk);
         
@@ -118,6 +128,8 @@ public class MorkoEnemy : MonoBehaviour
         }
 
     }
+
+    public void StopMorko() => _isMorkoStopped = true;
 
     private void OnCollisionEnter2D(Collision2D other)
     {


### PR DESCRIPTION
- Mörkö lair entrances ground collapses when player enters the lair
- Mörkö will stop the chase after reaching the edge of the collapsed ground